### PR TITLE
Add an option to control whether the title of the button is displayed #26

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,6 +15,7 @@ interface FabProps {
   icon: ReactElement;
   event?: 'hover' | 'click';
   children?: ReactElement[] | ReactElement;
+  showTitle: boolean;
 }
 
 type Action = (props: ActionProps & DOMAttributes<HTMLElement> & HTMLAttributes<HTMLElement>) => ReactElement;

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,6 @@ interface FabProps {
   icon: ReactElement;
   event?: 'hover' | 'click';
   children?: ReactElement[] | ReactElement;
-  showTitle: boolean;
 }
 
 type Action = (props: ActionProps & DOMAttributes<HTMLElement> & HTMLAttributes<HTMLElement>) => ReactElement;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable linebreak-style */
 import React from 'react';
 
 import './styles.scss';
@@ -49,7 +48,7 @@ class Fab extends React.Component {
     if (React.Children.count(c) > 6)
       console.warn('react-tiny-fab only supports up to 6 action buttons');
     return React.Children.map(c, (ch, i) => (
-      <li className={`rtf--ab__c ${showTitle ? 'rtf--ab__cc' : ''} ${'top' in p ? 'top' : ''}`}>
+      <li className={`rtf--ab__c ${alwaysShowTitle ? 'rtf--ab__cc' : ''} ${'top' in p ? 'top' : ''}`}>
         {React.cloneElement(ch, {
           'data-testid': `action-button-${i}`,
           'aria-label': ch.props.text || `Menu button ${i + 1}`,

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable linebreak-style */
 import React from 'react';
 
 import './styles.scss';
@@ -43,12 +44,12 @@ class Fab extends React.Component {
   };
 
   rc() {
-    const { children: c, position: p } = this.props;
+    const { children: c, position: p, showTitle } = this.props;
     const { open } = this.state;
     if (React.Children.count(c) > 6)
       console.warn('react-tiny-fab only supports up to 6 action buttons');
     return React.Children.map(c, (ch, i) => (
-      <li className={`rtf--ab__c ${'top' in p ? 'top' : ''}`}>
+      <li className={`rtf--ab__c ${showTitle ? 'rtf--ab__cc' : ''} ${'top' in p ? 'top' : ''}`}>
         {React.cloneElement(ch, {
           'data-testid': `action-button-${i}`,
           'aria-label': ch.props.text || `Menu button ${i + 1}`,

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -19,6 +19,14 @@
         padding: 0;
       }
     }
+
+    .rtf--ab__cc{
+      > span {
+        transition: ease-in-out opacity 0.2s;
+        opacity: 0.9;
+      }
+    }
+
     .rtf--ab__c {
       &:hover {
         > span {


### PR DESCRIPTION
> I added the option.
> Using like this:
> 
> ```js-jsx
> <Fab
>             mainButtonStyles={{ backgroundColor: '#304FFE' }}
>             position={{ bottom: 0, right: 0 }}
>             icon={<MdAdd />}
>             event='click'
>             key='1'
>             showTitle={true}
>         >
> ```
> 
> ![gifhome_360x566](https://user-images.githubusercontent.com/9806325/60435555-7b2c9180-9c3c-11e9-9504-edd3762abf42.gif)
> 
> To keep the original look, just remove the `showTitle` prop.

