### PR TITLE
Add text property to FAB & refine the logic while onClick enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ This is the main component that controls the Floating Action Button.
 | `icon`               | React Element/Component    |                           | true     | This element/component will be used as the icon for the main button. This can be text, or a Font Awesome icon, or any other component. |
 | `event`              | string                     | 'hover'                   | false    | What type of event do you want to make the FAB menu active? This can be either `click` or `hover`.                                         |
 | `children`           | React Element/Component    |                           | false    | This is the children that will be mapped and rendered. This can be anything. There can be up to 6, but no more than 6. An `Action` component is provided out of the box.           |
+| `onClick`            | function                   | null                      | false    | If you only need to use the main button for something, then you can attach an `onClick` handler to the main button. The React Synthetic Event will be passed in just like a normal `onClick` |
+| `text`               | string                     | null                      | false    | If you attach an `onClick` handler to the main button, then the original `Action` components would not show. Instead you can attach `text` to display while user hover the FAB |
 
 > Based on the `position` prop, the FAB will figure out the direction of the `<Action />` `text` and also which way to 
 > expand when hovered/clicked (up or down).

--- a/example/index.html
+++ b/example/index.html
@@ -160,6 +160,21 @@
       const App = () => (
         <React.Fragment>
           {renderComponents(components)}
+          <Fab
+            mainButtonStyles={{
+              backgroundColor: '#00b5ad',
+            }}
+            position={{
+              bottom: 100,
+              right: 100,
+            }}
+            icon="+"
+            event="hover"
+            key={-1}
+            alwaysShowTitle={false}
+            onClick={() => alert('Here is the action of FAB.')}
+            text="TextForFAB"
+          />
           <Help />
         </React.Fragment>
       );

--- a/src/example.mdx
+++ b/src/example.mdx
@@ -89,7 +89,8 @@ This is the main component that controls the Floating Action Button.
 | `event`              | string                     | 'hover'                   | false    | What type of event do you want to make the FAB menu active? This can be either `click` or `hover`.                                         |
 | `children`           | React Element/Component    |                           | false    | This is the children that will be mapped and rendered. This can be anything. There can be up to 6, but no more than 6. An `Action` component is provided out of the box.           |
 | `alwaysShowTitle`    | boolean                    | false                     | false    | If the title of the `Action` component should always be shown (not just on hover), set this to true and the title will always be shown |
-| `onClick`            | function                   | `() => {}`                 | false    | If you only need to use the main button for something, then you can attach an `onClick` handler to the main button. The React Synthetic Event will be passed in just like a normal `onClick` |
+| `onClick`            | function                   | null                      | false    | If you only need to use the main button for something, then you can attach an `onClick` handler to the main button. The React Synthetic Event will be passed in just like a normal `onClick` |
+| `text`               | string                     | null                      | false    | If you attach an `onClick` handler to the main button, then the original `Action` components would not show. Instead you can attach `text` to display while user hover the FAB |
 
 > Based on the `position` prop, the FAB will figure out the direction of the `<Action />` `text` and also which way to 
 > expand when hovered/clicked (up or down).

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -16,6 +16,8 @@ interface FabProps {
   event?: 'hover' | 'click';
   children?: ReactElement[] | ReactElement;
   alwaysShowTitle?: boolean;
+  text?: string;
+  onClick?: (e: any) => any;
 }
 
 type Action = (props: ActionProps & DOMAttributes<HTMLElement> & HTMLAttributes<HTMLElement>) => ReactElement;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -23,17 +23,20 @@ const Fab = ({
   children,
   icon,
   mainButtonStyles,
-  onClick = () => {},
+  onClick,
+  text,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
-
+  const ariaHidden = alwaysShowTitle || !isOpen;
   const open = () => setIsOpen(true);
   const close = () => setIsOpen(false);
   const enter = () => event === 'hover' && open();
   const leave = () => event === 'hover' && close();
   const toggle = e => {
+    if (onClick) {
+      return onClick(e);
+    }
     e.persist();
-    onClick(e);
     return event === 'click' ? (isOpen ? close() : open()) : null;
   };
 
@@ -47,7 +50,6 @@ const Fab = ({
   const rc = () => {
     if (React.Children.count(children) > 6)
       console.warn('react-tiny-fab only supports up to 6 action buttons');
-    const ariaHidden = alwaysShowTitle || !isOpen;
 
     return React.Children.map(
       children,
@@ -95,6 +97,16 @@ const Fab = ({
         >
           {icon}
         </MB>
+        {onClick && text && (
+          <span
+            className={`${'right' in position ? 'right' : ''} ${
+              alwaysShowTitle ? 'always-show' : ''
+            }`}
+            aria-hidden={ariaHidden}
+          >
+            {text}
+          </span>
+        )}
         <ul>{rc()}</ul>
       </li>
     </ul>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -82,6 +82,34 @@
   *:last-child {
     margin-bottom: 0;
   }
+  &:hover {
+    > span {
+      transition: ease-in-out opacity 0.2s;
+      opacity: 0.9;
+    }
+  }
+  > span.always-show {
+    transition: ease-in-out opacity 0.2s;
+    opacity: 0.9;
+  }
+  > span {
+    opacity: 0;
+    transition: ease-in-out opacity 0.2s;
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    margin-right: 6px;
+    margin-left: 4px;
+    background: rgba(0, 0, 0, 0.75);
+    padding: 2px 4px;
+    border-radius: 2px;
+    color: white;
+    font-size: 13px;
+    box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
+    &.right {
+      right: 100%;
+    }
+  }
 }
 
 .rtf--mb {


### PR DESCRIPTION
resolved following issues that can be improved.
1. When `onClick` for `<Fab/>` is enabled, the icon should not spin with an angle. It should act exactly like `<Action/>` do.
2. When `onClick` for `<Fab/>` is enabled, text can be shown while mouse hover on `<Fab/>`, just like `<Action/>` do. Therefore, one more property can be added into 
3. Update [index.d.ts](https://github.com/dericgw/react-tiny-fab/blob/master/src/index.d.ts) for Typescript users.