### PR TITLE
Resolving an aria-hidden-focus accessibility issue for hidden action buttons 

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -60,6 +60,7 @@ const Fab = ({
               'data-testid': `action-button-${i}`,
               'aria-label': ch.props.text || `Menu button ${i + 1}`,
               'aria-hidden': ariaHidden,
+              'tabIndex': isOpen ? 0 : -1,
               ...ch.props,
               onClick: () => actionOnClick(ch.props.onClick),
             })}


### PR DESCRIPTION
Presently, action buttons are focus-able when hidden from view. This can cause confusion for users with disabilities, many of whom rely on screen readers and other assistive technologies. This PR contains a small modification which sets the tabindex attribute of action buttons to -1 while isOpen is false and 0 while isOpen is true. This ensures the same usable access to the action buttons for users with disabilities and resolves the [aria-hidden-focus](https://dequeuniversity.com/rules/axe/3.3/aria-hidden-focus) error identified by Microsoft's [Accessibility Insights for Web](https://accessibilityinsights.io/docs/en/web/overview) tool.