### PR TITLE
Fixes #35 - Fixed an issue that caused input fields to be minimized when clicked

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -60,7 +60,10 @@ const Fab = ({
               'aria-hidden': ariaHidden,
               tabIndex: isOpen ? 0 : -1,
               ...ch.props,
-              onClick: e => actionOnClick(e, ch.props.onClick),
+              onClick: e => {
+                if (ch.props.onClick)
+                  actionOnClick(e, ch.props.onClick)
+              },
             })}
             {ch.props.text && (
               <span


### PR DESCRIPTION
The fields were closing due to the passed in function for the children being 'undefined'. This would show up in the console upon clicking inside the div.