### PR TITLE
Make main button accessible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tiny-fab",
-  "version": "4.0.0",
+  "version": "4.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -61,7 +61,7 @@ const Fab: React.FC<FabProps> = ({
     // }
     e.persist();
     // return event === 'click' ? (isOpen ? close() : open()) : null;
-    return event === 'click' ? setIsOpen(!isOpen) : null;
+    return setIsOpen(!isOpen);
   };
 
   const actionOnClick = (e: React.FormEvent, userFunc: (e: React.FormEvent) => void) => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -55,11 +55,12 @@ const Fab: React.FC<FabProps> = ({
   const enter = () => event === 'hover' && open();
   const leave = () => event === 'hover' && close();
   const toggle = (e: React.FormEvent) => {
-    if (onClick) {
-      return onClick(e);
-    }
+    // if (onClick) {
+    //   return onClick(e);
+    // }
     e.persist();
-    return event === 'click' ? (isOpen ? close() : open()) : null;
+    // return event === 'click' ? (isOpen ? close() : open()) : null;
+    return event === 'click' ? setIsOpen(!isOpen) : null;
   };
 
   const actionOnClick = (e: React.FormEvent, userFunc: (e: React.FormEvent) => void) => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -55,6 +55,7 @@ const Fab: React.FC<FabProps> = ({
   const enter = () => event === 'hover' && open();
   const leave = () => event === 'hover' && close();
   const toggle = (e: React.FormEvent) => {
+    console.log('toggled');
     // if (onClick) {
     //   return onClick(e);
     // }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -55,12 +55,10 @@ const Fab: React.FC<FabProps> = ({
   const enter = () => event === 'hover' && open();
   const leave = () => event === 'hover' && close();
   const toggle = (e: React.FormEvent) => {
-    console.log('toggled');
-    // if (onClick) {
-    //   return onClick(e);
-    // }
+    if (onClick) {
+      onClick(e);
+    }
     e.persist();
-    // return event === 'click' ? (isOpen ? close() : open()) : null;
     return setIsOpen(!isOpen);
   };
 


### PR DESCRIPTION
The `toggle` callback currently does not allow the user to toggle the fab menu by focusing on the main button and pressing `Enter`.

We made these tweaks in the callback : 
a) Remove `return` keyword in `if(onClick)` block to prevent the `onClick` prop from blocking toggle
b) Remove limitation of `click` events only for toggling

The fab menu now toggles open/closed when the user tabs to the button and presses `Enter`.

Not sure if this would be a breaking change for others, but in our case it retained all the fab hover and dynamic onClick functionality without sacrificing accessibility. 