### PR TITLE
Fix Fab component toggle behavior on click events

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -57,6 +57,7 @@ const Fab: React.FC<FabProps> = ({
   const leave = () => interpolatedEvent === 'hover' && close();
   const toggle = (e: React.FormEvent) => {
     if (onClick) {
+      isOpen ? close() : open() 
       return onClick(e);
     }
     e.persist();


### PR DESCRIPTION
This commit addresses an issue with the Fab component where click events were not properly triggering the toggle behavior (open/close). The problem was observed when the `onClick` prop is used with an event set to "click", leading to an unexpected behavior where the Fab component neither opens nor closes as intended.